### PR TITLE
Update gyp script to adapt new Android 20 name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 ## Introduction
 This repository includes external extensions written for Crosswalk Android port.
+Fore more details, please refer to https://crosswalk-project.org/#documentation/android_extensions
 
-## Packaging an external extension
-Please refer to https://crosswalk-project.org/#wiki/Writing-a-Crosswalk-Java-Extension-on-Android
+## Prerequisites
+1. gyp
+https://code.google.com/p/gyp/
+Use `which gyp` to double check.
+
+2. depot_tools
+http://dev.chromium.org/developers/how-tos/install-depot-tools
+Use `which gclient` to double check.
+
+3. Android SDK
+http://developer.android.com/sdk/index.html
+Use `which aidl` to double check.
+
+4. Crosswalk
+https://crosswalk-project.org/#documentation/downloads
+Use `which make_apk.py` to double check.
+
+## Building an external extension
+export GYP_GENERATORS='ninja'
+./gyp_extensions
+ninja -C out/Default # or for individual target as follows
+ninja -C out/Default iap
 
 ## License
 This project's code uses the Apache license, see our `LICENSE.AL2` file.

--- a/build/common.gypi
+++ b/build/common.gypi
@@ -5,14 +5,9 @@
 {
   'variables': {
     'variables': {
-      'variables': {
-        'android_version%': '<!(basename $(dirname $(which aidl))|cut -d. -f1)',
-      },
       'android_sdk_root%': '<!(dirname $(dirname $(dirname $(which aidl))))',
-      'android_sdk_version%': '<(android_version)',
-      'android_sdk_build_tools_version%': '<(android_version).0.0',
     },
-    'android_sdk%': '<(android_sdk_root)/platforms/android-<(android_sdk_version)',
-    'android_sdk_tools%': '<(android_sdk_root)/build-tools/<(android_sdk_build_tools_version)',
+    'android_sdk%': '<!(ls -d <(android_sdk_root)/platforms/*|tail -1)',
+    'android_sdk_tools%': '<!(dirname $(which aidl))',
   },
 }

--- a/iap/README
+++ b/iap/README
@@ -1,4 +1,4 @@
-How to build the IAP extension with your application:
+How to package the IAP extension with your application:
 
   cd $(dirname $(which make_apk.py))
   python make_apk.py --name=iap --package=org.xwalk.extensions.iap --permissions=iap --extensions="/<path-to-xwalk-android-extension>/out/Default/gen/iap/" --arch=x86 --manifest=/<path-to-xwalk-android-extension>/examples/iap/iap.json


### PR DESCRIPTION
We were using "??.0.0" to match android sdk tool path, e.g. "18.0.0",
"19.0.0". Now android 20 is using another name - "android-4.4W"
So we need to change the matching pattern accordingly.

BUG=https://crosswalk-project.org/jira/browse/XWALK-2117
