### PR TITLE
[REG] fails to add repo by extension_manager.py

### DIFF
--- a/idl_demo/idl_demo.gyp
+++ b/idl_demo/idl_demo.gyp
@@ -41,7 +41,7 @@
         'js_file': '<(gen_js_file)',
         'json_file': '<(component).json',
         'input_jars_paths': [
-          '<!(dirname $(which make_apk.py))/libs/xwalk_app_runtime_java.jar',
+          '<!(dirname $(which make_apk.py))/template/libs/xwalk_app_runtime_java.jar',
           '<(android_jar)',
         ],
       },


### PR DESCRIPTION
The added repo is https://github.com/crosswalk-project/crosswalk-android-extensions.git
Root cause:
idl_demo.gyp in this repo has wrong path to xwalk_app_runtime_java.jar.

BUG=XWALK-2608
