### PR TITLE
[REG] Fix path of app_runtime_java.jar

### DIFF
--- a/build/common.gypi
+++ b/build/common.gypi
@@ -9,5 +9,6 @@
     },
     'android_sdk%': '<!(ls -d <(android_sdk_root)/platforms/*|tail -1)',
     'android_sdk_tools%': '<!(dirname $(which aidl))',
+    'app_runtime_java_jar%': '<!(find $(dirname $(which make_apk.py))|grep xwalk_app_runtime_java.jar|tail -1)',
   },
 }

--- a/iap/iap.gyp
+++ b/iap/iap.gyp
@@ -37,7 +37,7 @@
         'js_file': '<(DEPTH)/iap/iap.js',
         'json_file': '<(DEPTH)/iap/iap.json',
         'input_jars_paths': [
-          '<!(dirname $(which make_apk.py))/template/libs/xwalk_app_runtime_java.jar',
+          '<(app_runtime_java_jar)',
           '<(android_jar)',
         ],
       },

--- a/idl_demo/idl_demo.gyp
+++ b/idl_demo/idl_demo.gyp
@@ -41,7 +41,7 @@
         'js_file': '<(gen_js_file)',
         'json_file': '<(component).json',
         'input_jars_paths': [
-          '<!(dirname $(which make_apk.py))/libs/xwalk_app_runtime_java.jar',
+          '<(app_runtime_java_jar)',
           '<(android_jar)',
         ],
       },


### PR DESCRIPTION
Avoid using hard-coded path for `app_runtime_java.jar` so that we don't depend on file location in xwalk package.

BUG=XWALK-2608
