### PR TITLE
[IAP]Correct the error name

### DIFF
--- a/iap/src/org/xwalk/extensions/InAppPurchaseHelper.java
+++ b/iap/src/org/xwalk/extensions/InAppPurchaseHelper.java
@@ -21,7 +21,7 @@ public class InAppPurchaseHelper {
 
     // The names of different errors.
     public static final String OPERATION_ERROR = "OperationError";
-    public static final String NOT_SUPPORTED_ERROR = "NotSupportError";
+    public static final String NOT_SUPPORTED_ERROR = "NotSupportedError";
 
     public InAppPurchaseHelper(Activity activity, int instanceId, InAppPurchaseHelperListener listener) {
         mActivity = activity;


### PR DESCRIPTION
To comply with the spec (http://crosswalk-project.github.io/
ios-extensions-crosswalk/extensions/InAppPurchase/spec/iap.html), when
the backend meets a channel which is not supported, the returned error name
should exactly equal to "NotSupportedError".

BUG=XWALK-6794