### PR TITLE
[IAP]Throw an error when the options.channel is undefined

### DIFF
--- a/iap/iap.js
+++ b/iap/iap.js
@@ -37,6 +37,8 @@ exports.init = function(options) {
   return new Promise(function(resolve, reject) {
     if (g_initialized)
       throw new DOMError("InvalidStateError");
+    if (typeof(options.channel) === "undefined")
+      throw new DOMError("InvalidAccessError");
     var resolveWrapper = function() {
       g_initialized = true;
       resolve();


### PR DESCRIPTION
If the options.channel is undefined, when passing it to navigator.iap.init()
method, the Promise should be rejected and an error named
"InvalidAccessError" is thrown also.

BUG=XWALK-6798