### PR TITLE
[IAP]Throw an error when the order.productId is undefined

### DIFF
--- a/iap/iap.js
+++ b/iap/iap.js
@@ -64,6 +64,9 @@ exports.purchase = function(order) {
     if (!g_initialized) {
       throw new DOMError("InvalidStateError");
     }
+    if (typeof(order.productId) === "undefined") {
+      throw new DOMError("InvalidAccessError");
+    }
     var requestId = createAsyncRequest(resolve, reject);
     sendAsycRequest("purchase", requestId, order);
   });


### PR DESCRIPTION
If the order.produectId is undefined, when passing it to
navigator.iap.purchase() method, the Promise should be rejected and
an error named "InvalidAccessError" is thrown also.

BUG=XWALK-6895