### PR TITLE
[IAP]Throw an error when productIds is undefined

### DIFF
--- a/iap/iap.js
+++ b/iap/iap.js
@@ -53,6 +53,8 @@ exports.queryProductsInfo = function(productIds) {
     if (!g_initialized) {
       throw new DOMError("InvalidStateError");
     }
+    if (typeof(productIds) === "undefined")
+      throw new DOMError("InvalidAccessError");
     var requestId = createAsyncRequest(resolve, reject);
     sendAsycRequest("queryProductsInfo", requestId, productIds);
   });


### PR DESCRIPTION
When calling queryProductsInfo with the productIds, which is undefined,
the Promise should reject with an error named "InvalidAccessError".

BUG=XWAL-6931